### PR TITLE
Compile error is happening, so as to reload.

### DIFF
--- a/lib/again.pm
+++ b/lib/again.pm
@@ -12,7 +12,7 @@ sub require_again {
     @_ >  1 and croak 'Too many arguments for require_again';
     my $module = shift;
     (my $file = "$module.pm") =~ s[::][/]g;
-    if (not exists $INC{$file} or -M $INC{$file} < $mtimes{$INC{$file}}) {
+    if (not exists $INC{$file} or not defined $INC{$file} or -M $INC{$file} < $mtimes{$INC{$file}}) {
         delete $INC{$file};
         require $file;
         $mtimes{$INC{$file}} = -M $INC{$file};


### PR DESCRIPTION
Hello.

If a compilation failed occurs with a require_again("Module"), undef is set to $INC{"Module.pm"}.
I have never "-M $INC{$file} < $mtimes{$INC{$file}}" of again.pm:L15 is true future.
I also update the Module.pm.

Is this behavior specification?

Compilation failed is happening, I tried to change it to reload.

If this could be the desired behavior if, please merge.

Cheers,
Tomohiro Hosaka

```
use strict;
use feature ":5.10";
use again;
use IO::All;

eval {
    io('myModule.pm')->print("package myModule; sub mysub { '1' }; 1;");
    require_again('myModule');
    say $INC{'myModule.pm'};
    say myModule::mysub();
};
say $@ if $@;

eval {
    sleep 1;
    io('myModule.pm')->print("package myModule; sub mysub { '2' }; 1;");
    require_again('myModule');
    say $INC{'myModule.pm'};
    say myModule::mysub();
};
say $@ if $@;

eval {
    sleep 1;
    io('myModule.pm')->print("package myModule; sub mysub { '3 }; 1;");
    require_again('myModule');
    say $INC{'myModule.pm'};
    say myModule::mysub();
};
say $@ if $@;

eval {
    sleep 1;
    io('myModule.pm')->print("package myModule; sub mysub { '4' }; 1;");
    require_again('myModule');
    say $INC{'myModule.pm'};
    say myModule::mysub();
};
say $@ if $@;

__END__

myModule.pm
1
myModule.pm
2
Can't find string terminator "'" anywhere before EOF at myModule.pm line 1.
Compilation failed in require at /home/bokutin/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/again.pm line 17.

Use of uninitialized value in -M at /home/bokutin/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/again.pm line 15.
Use of uninitialized value within %INC in hash element at /home/bokutin/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/again.pm line 15.
Use of uninitialized value in numeric lt (<) at /home/bokutin/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/again.pm line 15.
Use of uninitialized value in numeric lt (<) at /home/bokutin/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/again.pm line 15.

2
```
